### PR TITLE
feature/validate imprint is clickable

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+## Describe your changes
+
+## Issue ticket number and link
+
+## Checklist before requesting a review
+- [ ] I have performed a self-review of my code

--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ A plugin to extend cypress commands with useful functions to make daily work muc
 
 Add following line in your cypress/support/e2e.js:
 
-`import 'cypress-lmc-plugin'`
+```js
+import 'cypress-lmc-plugin'
+```
 
 ### Extend cypress.config.js
 
-Make sure you have specified a baseUrl in the cypress configuration.
+Make sure you have specified a baseUrl in the cypress configuration:
 
 ```js
 module.exports = defineConfig({
@@ -24,7 +26,7 @@ module.exports = defineConfig({
 
 ## Usage
 
-Once you have completed the installation, you can access the functions of the plugin and use them in your spec, e.g:
+Once you have completed the installation, you can access the plugins functions and use them in your spec, e.g:
 
 ```js
 describe('Make sure cookie bot can be accepted', () => {

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Make sure you have specified a baseUrl in the cypress configuration:
 ```js
 module.exports = defineConfig({
   e2e: {
-    baseUrl: 'https://please,test-your-website.com/'
+    baseUrl: 'https://please.test-your-website.com/'
   },
 });
 ```

--- a/README.md
+++ b/README.md
@@ -4,9 +4,15 @@ A plugin to extend cypress commands with useful functions to make daily work muc
 
 ## Installation
 
+You can install the cypress plugin via npm:
+
+```bash
+npm i cypress-lmc-plugin
+```
+
 ### Extend "cypress/support/e2e"
 
-Add following line in your cypress/support/e2e.js:
+Add the following line to your cypress/support/e2e.js to import the plugin functions:
 
 ```js
 import 'cypress-lmc-plugin'
@@ -19,22 +25,22 @@ Make sure you have specified a baseUrl in the cypress configuration:
 ```js
 module.exports = defineConfig({
   e2e: {
-    baseUrl: 'https://www,your-website.com/'
+    baseUrl: 'https://please,test-your-website.com/'
   },
 });
 ```
 
 ## Usage
 
-Once you have completed the installation, you can access the plugins functions and use them in your spec, e.g:
+Once you have completed the installation, you can access the plugin functions and use them in your specs, e.g:
 
 ```js
 describe('Make sure cookie bot can be accepted', () => {
   it('passes', () => {
     cy.visit('/')
     cy.acceptCookieBot()
-  })
-})
+  });
+});
 ```
 
 ## Credits and blog post links

--- a/src/commands.js
+++ b/src/commands.js
@@ -4,4 +4,4 @@ import { validateImprintLinkIsClickable } from './commands/validate-imprint-link
 
 Cypress.Commands.add('acceptCookieBot', acceptCookieBot);
 Cypress.Commands.add('authorizeAgainstHtaccess', authorizeAgainstHtaccess);
-Cypress.Commands.add('validateImprintIsClickable', validateImprintLinkIsClickable);
+Cypress.Commands.add('validateImprintLinkIsClickable', validateImprintLinkIsClickable);

--- a/src/commands.js
+++ b/src/commands.js
@@ -1,5 +1,7 @@
 import { acceptCookieBot } from './commands/accept-cookiebot';
 import { authorizeAgainstHtaccess } from './commands/authorize-against-htaccess';
+import { validateImprintLinkIsClickable } from './commands/validate-imprint-link-is-clickable';
 
 Cypress.Commands.add('acceptCookieBot', acceptCookieBot);
 Cypress.Commands.add('authorizeAgainstHtaccess', authorizeAgainstHtaccess);
+Cypress.Commands.add('validateImprintIsClickable', validateImprintLinkIsClickable);

--- a/src/commands/validate-imprint-link-is-clickable.js
+++ b/src/commands/validate-imprint-link-is-clickable.js
@@ -1,0 +1,26 @@
+/// <reference types="Cypress" />
+export const validateImprintLinkIsClickable = (imprintLinkSelector = 'footer a[title="Impressum"]') => {
+  cy.visit(Cypress.env('baseUrl'));
+
+  cy.log('Verify that imprint link is available');
+  cy.get(imprintLinkSelector)
+   .should('exist')
+   .should('be.visible')
+   .contains('Impressum')
+   .invoke('attr', 'href')
+   .then((imprintLinkHref) => {
+     cy.log('Verify that imprint link is clickable and ends in HTTP 200');
+     cy.log(imprintLinkHref);
+     cy.request({
+       url: imprintLinkHref,
+       followRedirect: false,
+     }).then(response => {
+       expect(response.status).to.eq(200);
+       expect(response.statusText).to.eq('OK');
+       expect(response.redirectedToUrl).to.eq(undefined);
+     }).then(() => {
+       cy.visit(Cypress.env('baseUrl') + imprintLinkHref);
+       cy.get('h1').should('exist').should('be.visible').contains('Impressum');
+      });
+    });
+};

--- a/src/commands/validate-imprint-link-is-clickable.js
+++ b/src/commands/validate-imprint-link-is-clickable.js
@@ -8,6 +8,7 @@ export const validateImprintLinkIsClickable = (imprintLinkSelector = 'footer a[t
    .should('be.visible')
    .contains('Impressum')
    .invoke('attr', 'href')
+   .should('not.be.empty')
    .then((imprintLinkHref) => {
      cy.log('Verify that imprint link is clickable and ends in HTTP 200');
      cy.log(imprintLinkHref);

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import { acceptCookieBot } from './commands/accept-cookiebot';
 import { authorizeAgainstHtaccess } from './commands/authorize-against-htaccess';
-import { validateImprintLinkIsClickable } from './commands/validate-imprint-is-clickable';
+import { validateImprintLinkIsClickable } from './commands/validate-imprint-link-is-clickable';
 
 Cypress.Commands.add('acceptCookieBot', acceptCookieBot);
 Cypress.Commands.add('authorizeAgainstHtaccess', authorizeAgainstHtaccess);

--- a/src/index.js
+++ b/src/index.js
@@ -4,4 +4,4 @@ import { validateImprintLinkIsClickable } from './commands/validate-imprint-link
 
 Cypress.Commands.add('acceptCookieBot', acceptCookieBot);
 Cypress.Commands.add('authorizeAgainstHtaccess', authorizeAgainstHtaccess);
-Cypress.Commands.add('validateImprintIsClickable', validateImprintLinkIsClickable);
+Cypress.Commands.add('validateImprintLinkIsClickable', validateImprintLinkIsClickable);

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 import { acceptCookieBot } from './commands/accept-cookiebot';
 import { authorizeAgainstHtaccess } from './commands/authorize-against-htaccess';
+import { validateImprintLinkIsClickable } from './commands/validate-imprint-is-clickable';
 
 Cypress.Commands.add('acceptCookieBot', acceptCookieBot);
 Cypress.Commands.add('authorizeAgainstHtaccess', authorizeAgainstHtaccess);
+Cypress.Commands.add('validateImprintIsClickable', validateImprintLinkIsClickable);


### PR DESCRIPTION
## Describe your changes
This feature adds a new custom command which validates the imprint link according to the following criteria:
- The imprint link is existent and visible
- The imprint link contains the text "Impressum"
- The imprint link redirects the user to the imprint page which is loaded with the status code HTTP 200 and was not forwarded by a redirect.

This changes includes an update of the README.md file which now has a installation section.
